### PR TITLE
deprecated circleci image to cimg (#74)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     working_directory: ~/hawkBit-examples
 
     docker:
-    - image: circleci/openjdk:11.0.13-jdk-buster
+    - image: cimg/openjdk:17.0.7
       auth:
         username: $DOCKERHUB_USER
         password: $DOCKERHUB_ACCESSTOKEN

--- a/licenses/LICENSE_HEADER_TEMPLATE_BOSCH_23.txt
+++ b/licenses/LICENSE_HEADER_TEMPLATE_BOSCH_23.txt
@@ -1,0 +1,6 @@
+Copyright (c) 2023 Bosch.IO GmbH and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
    <parent>
       <groupId>org.eclipse.hawkbit</groupId>
       <artifactId>hawkbit-parent</artifactId>
-      <version>0.3.0M8</version>
+      <version>0.3.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>hawkbit-examples-parent</artifactId>
@@ -46,7 +46,7 @@
    </modules>
 
    <properties>
-      <hawkbit.version>0.3.0M8</hawkbit.version>
+      <hawkbit.version>0.3.0-SNAPSHOT</hawkbit.version>
       
       <!-- Release - START -->
       <release.scm.connection>scm:git:git@github.com:eclipse/hawkbit-examples.git</release.scm.connection>


### PR DESCRIPTION
* deprecated circleci image to cimg



* add license template



* Refer latest hawkbit snapshot


* add snaposhot repository for circleci build

* reevert changes for repositories

---------